### PR TITLE
Fixed a bug where the Graphics.SmoothingMode is incorrectly reported

### DIFF
--- a/System.Drawing/Graphics.cs
+++ b/System.Drawing/Graphics.cs
@@ -1157,6 +1157,7 @@ namespace System.Drawing {
 			{
 				// Quartz performs antialiasing for a graphics context if both the allowsAntialiasing parameter 
 				// and the graphics state parameter shouldAntialias are true.
+				smoothingMode = value;
 				switch (value) 
 				{
 				case SmoothingMode.AntiAlias:


### PR DESCRIPTION
This meant if no matter what SmoothingMode you set it would always return SmoothingMode.Default.