### PR TITLE
Fix memory management issues resulting in double-free or memory leak.

### DIFF
--- a/System.Drawing/Bitmap.cs
+++ b/System.Drawing/Bitmap.cs
@@ -574,7 +574,7 @@ namespace System.Drawing {
 			bitmap.DrawImage (new CGRect (0, 0, image.Width, image.Height), image);
 
 			this.bitmapBlock = bitmapBlock;
-			this.dataProvider = new CGDataProvider (bitmapBlock, size);
+			this.dataProvider = new CGDataProvider (bitmapBlock, size, true);
 			NativeCGImage = new CGImage (width, height, bitsPerComponent, 
 			                             bitsPerPixel, bytesPerRow, 
 			                             colorSpace,
@@ -708,8 +708,10 @@ namespace System.Drawing {
 			// Set our transform for this image for the new height
 			imageTransform = new CGAffineTransform(1, 0, 0, -1, 0, height);
 
-			if (bitmapBlock != IntPtr.Zero)
-				Marshal.FreeHGlobal(bitmapBlock);
+			// bitmapBlock is owned by dataProvider and freed implicitly
+			if (dataProvider != null)
+				dataProvider.Dispose();
+
 			if (cachedContext != null)
 				cachedContext.Dispose();
 			NativeCGImage.Dispose();


### PR DESCRIPTION
Fixes two distinct issues:
- Calling RotateFlip on Bitmaps create in certain way freed the bitmap memory that was still referenced by CGDataProvider object. When the CGDataProvider object got finalized it resulted in double free and crash.
- In some code paths the internal CGDataProvider was constructed from an allocated buffer, but the ownBuffer parameter was not set to true. This resulted in leak of unmanaged memory.