### PR TITLE
fix what resolve issue NSTextField non-system-font content clipped wh…

### DIFF
--- a/System.Drawing/SystemFonts.cs
+++ b/System.Drawing/SystemFonts.cs
@@ -8,7 +8,7 @@ namespace System.Drawing {
 		static SystemFonts ()
 		{
 			CaptionFont = new Font(new CTFont(CTFontUIFontType.WindowTitle, 0, null));
-			DefaultFont = new Font(new CTFont(CTFontUIFontType.Label, 0, null));
+			DefaultFont = new Font(new CTFont(CTFontUIFontType.ControlContent, 0, null));
 			DialogFont = new Font(new CTFont(CTFontUIFontType.Label, 0, null));
 			IconTitleFont = new Font(new CTFont(CTFontUIFontType.Label, 0, null));
 			MenuFont = new Font(new CTFont(CTFontUIFontType.MenuItem, 0, null));


### PR DESCRIPTION
…en usesSingleLineMode is true

this change make for resolve this issue:

https://stackoverflow.com/questions/36179012/nstextfield-non-system-font-content-clipped-when-usessinglelinemode-is-true

